### PR TITLE
Add BuildKonfig to store keys

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.buildKonfig) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,5 +1,8 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -7,6 +10,22 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.buildKonfig)
+}
+
+val localProperties = Properties().apply {
+    FileInputStream(rootProject.file("local.properties")).use { load(it) }
+}
+
+val marvelPublicKey = localProperties.getProperty("MARVEL_PUBLIC_KEY") ?: "unknown"
+val marvelPrivateKey = localProperties.getProperty("MARVEL_PRIVATE_KEY") ?: "unknown"
+
+buildkonfig {
+    packageName = "com.sngular.marvelkmp"
+    defaultConfigs {
+        buildConfigField(STRING, "MARVEL_PUBLIC_KEY", marvelPublicKey)
+        buildConfigField(STRING, "MARVEL_PRIVATE_KEY", marvelPrivateKey)
+    }
 }
 
 kotlin {
@@ -16,7 +35,7 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
-    
+
     listOf(
         iosX64(),
         iosArm64(),
@@ -99,4 +118,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-

--- a/composeApp/src/androidMain/kotlin/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/Platform.android.kt
@@ -1,3 +1,4 @@
+import com.sngular.marvelkmp.BuildKonfig
 import io.github.alexzhirkevich.cupertino.adaptive.Theme
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -9,7 +10,6 @@ import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
-import utils.marvelPublicApiKey
 
 actual fun isAndroid(): Boolean = true
 
@@ -35,8 +35,16 @@ actual fun getHttpClient(): HttpClient {
             url {
                 host = "gateway.marvel.com"
                 protocol = URLProtocol.HTTPS
-                parameters.append("apikey", marvelPublicApiKey)
+                parameters.append("apikey", getMarvelPublicKey())
             }
         }
     }
+}
+
+actual fun getMarvelPublicKey(): String {
+    return BuildKonfig.MARVEL_PUBLIC_KEY
+}
+
+actual fun getMarvelPrivateKey(): String {
+    return BuildKonfig.MARVEL_PRIVATE_KEY
 }

--- a/composeApp/src/commonMain/kotlin/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/Platform.kt
@@ -6,3 +6,7 @@ expect fun determineTheme(): Theme
 expect fun isAndroid(): Boolean
 
 expect fun getHttpClient(): HttpClient
+
+expect fun getMarvelPublicKey(): String
+
+expect fun getMarvelPrivateKey(): String

--- a/composeApp/src/commonMain/kotlin/di/NetworkModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/NetworkModule.kt
@@ -1,22 +1,7 @@
 package di
 
 import getHttpClient
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logger
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.plugins.logging.SIMPLE
-import io.ktor.http.URLProtocol
-import io.ktor.serialization.kotlinx.json.json
-import isAndroid
-import kotlinx.datetime.LocalDateTime
-import kotlinx.serialization.json.Json
 import org.koin.dsl.module
-import utils.marvelPublicApiKey
-
 
 val provideHttpClientModule = module {
     single {

--- a/composeApp/src/commonMain/kotlin/utils/Constants.kt
+++ b/composeApp/src/commonMain/kotlin/utils/Constants.kt
@@ -1,4 +1,0 @@
-package utils
-
-const val marvelPublicApiKey = ""
-const val marvelPrivateApiKey = ""

--- a/composeApp/src/commonMain/kotlin/utils/HttpRequestBuilders.kt
+++ b/composeApp/src/commonMain/kotlin/utils/HttpRequestBuilders.kt
@@ -1,5 +1,7 @@
 package utils
 
+import getMarvelPrivateKey
+import getMarvelPublicKey
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.parameter
 import io.ktor.utils.io.core.toByteArray
@@ -16,7 +18,7 @@ private fun md5Digest(toByteArray: ByteArray): String {
 
 fun HttpRequestBuilder.authorized() {
     val ts = Clock.System.now().epochSeconds.toString()
-    val hash = md5Digest("$ts$marvelPrivateApiKey$marvelPublicApiKey".toByteArray())
+    val hash = md5Digest("$ts${getMarvelPrivateKey()}${getMarvelPublicKey()}".toByteArray())
     parameter("ts", ts)
     parameter("hash", hash)
 }

--- a/composeApp/src/iosMain/kotlin/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/Platform.ios.kt
@@ -10,7 +10,6 @@ import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
-import utils.marvelPublicApiKey
 
 actual fun isAndroid(): Boolean = false
 
@@ -36,8 +35,16 @@ actual fun getHttpClient(): HttpClient {
             url {
                 host = "gateway.marvel.com"
                 protocol = URLProtocol.HTTPS
-                parameters.append("apikey", marvelPublicApiKey)
+                parameters.append("apikey", getMarvelPublicKey())
             }
         }
     }
+}
+
+actual fun getMarvelPublicKey(): String {
+    return com.sngular.marvelkmp.BuildKonfig.MARVEL_PUBLIC_KEY
+}
+
+actual fun getMarvelPrivateKey(): String {
+    return com.sngular.marvelkmp.BuildKonfig.MARVEL_PRIVATE_KEY
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ kamel = "0.9.5"
 okio = "3.9.0"
 kotlin-crypto = "0.5.1"
 androidx-navigation = "2.7.0-alpha07"
+buildKonfig = "0.15.0"
 
 [libraries]
 cupertino = { module = "io.github.alexzhirkevich:cupertino-adaptive", version = "0.1.0-alpha04" }
@@ -52,3 +53,4 @@ jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }


### PR DESCRIPTION
[FEAT] Implemented use of buildKonfig to store keys in local.properties instead in Constants to avoid upload them to repository.